### PR TITLE
feat(webrtc): add ICE transfer and relay fallback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,14 @@
 # jellyfederation Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-04-14
+Auto-generated from all feature plans. Last updated: 2026-04-15
 
 ## Active Technologies
 - C# on .NET 9 (plugin/server), with shared library multi-targeted net9.0/net10.0 + ASP.NET Core SignalR, EF Core (SQLite), OpenTelemetry, `System.Net.Quic` (BCL) (002-document-quic-support)
 - SQLite via EF Core (`FileRequests` table + migration for transfer metadata) (002-document-quic-support)
 - C# on .NET 9/10 (`net9.0` for plugin/server, multi-targeted shared library) + ASP.NET Core MVC + SignalR, EF Core (SQLite), OpenTelemetry, Jellyfin plugin APIs (003-add-result-monads)
 - SQLite via EF Core (`FileRequest`, `Invitation`, `MediaItem`, `RegisteredServer`); in-memory state for active transfer sessions (003-add-result-monads)
+- C# on .NET 9 (plugin), .NET 10 (server) (004-webrtc-datachannel)
+- No new storage. `FileRequest` EF entity gains a `TransportMode` column (already exists as `SelectedTransportMode`). (004-webrtc-datachannel)
 
 - C# (.NET 9/10; `net9.0`, `net10.0`) + ASP.NET Core, SignalR, Entity Framework Core (SQLite), Jellyfin plugin APIs, OpenTelemetry .NET SDK (001-run-speckit-feature)
 
@@ -27,10 +29,10 @@ tests/
 C# (.NET 9/10; `net9.0`, `net10.0`): Follow standard conventions
 
 ## Recent Changes
+- 004-webrtc-datachannel: Added C# on .NET 9 (plugin), .NET 10 (server)
 - 003-add-result-monads: Added C# on .NET 9/10 (`net9.0` for plugin/server, multi-targeted shared library) + ASP.NET Core MVC + SignalR, EF Core (SQLite), OpenTelemetry, Jellyfin plugin APIs
 - 002-document-quic-support: Added C# on .NET 9 (plugin/server), with shared library multi-targeted net9.0/net10.0 + ASP.NET Core SignalR, EF Core (SQLite), OpenTelemetry, `System.Net.Quic` (BCL)
 
-- 001-run-speckit-feature: Added C# (.NET 9/10; `net9.0`, `net10.0`) + ASP.NET Core, SignalR, Entity Framework Core (SQLite), Jellyfin plugin APIs, OpenTelemetry .NET SDK
 
 <!-- MANUAL ADDITIONS START -->
 

--- a/src/JellyFederation.Plugin/Configuration/PluginConfiguration.cs
+++ b/src/JellyFederation.Plugin/Configuration/PluginConfiguration.cs
@@ -23,14 +23,16 @@ public class PluginConfiguration : BasePluginConfiguration
     public string DownloadDirectory { get; set; } = string.Empty;
 
     /// <summary>
-    ///     Optional: override the public IP this server advertises for hole punching.
-    ///     Useful when running behind NAT or in Docker. Leave empty to auto-detect.
+    ///     Optional hint for backward-compat peers: override the public IP this server advertises for hole punching.
+    ///     Only relevant when communicating with peers running old plugin versions (pre-WebRTC ICE).
+    ///     Leave empty to auto-detect. WebRTC ICE peers handle NAT traversal automatically.
     /// </summary>
     public string OverridePublicIp { get; set; } = string.Empty;
 
     /// <summary>
-    ///     UDP port to bind for hole punching. Set a fixed port when behind NAT/Docker
-    ///     so you can port-forward it. 0 = ephemeral (auto).
+    ///     Optional hint for backward-compat peers: UDP port to bind for hole punching.
+    ///     Only relevant when communicating with peers running old plugin versions (pre-WebRTC ICE).
+    ///     0 = ephemeral (auto). WebRTC ICE peers do not require a fixed port.
     /// </summary>
     public int HolePunchPort { get; set; } = 0;
 
@@ -44,6 +46,12 @@ public class PluginConfiguration : BasePluginConfiguration
     ///     Transfers at or above this size are considered large-file QUIC candidates.
     /// </summary>
     public long LargeFileQuicThresholdBytes { get; set; } = 512L * 1024 * 1024;
+
+    /// <summary>
+    ///     STUN server used for WebRTC ICE candidate gathering.
+    ///     Default is Google's public STUN server. Override for air-gapped deployments.
+    /// </summary>
+    public string StunServer { get; set; } = "stun.l.google.com:19302";
 
     public string TelemetryServiceName { get; set; } = "jellyfederation-plugin";
     public string TelemetryOtlpEndpoint { get; set; } = "http://localhost:4317";

--- a/src/JellyFederation.Plugin/JellyFederation.Plugin.csproj
+++ b/src/JellyFederation.Plugin/JellyFederation.Plugin.csproj
@@ -29,6 +29,8 @@
         </PackageReference>
         <!-- SignalR client — ship it, but strip its Microsoft.Extensions.* transitive deps below -->
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.13"/>
+        <!-- WebRTC DataChannel stack — shipped with the plugin (natives in runtimes/linux-x64/native/) -->
+        <PackageReference Include="SIPSorcery" Version="10.0.3"/>
         <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12"/>
     </ItemGroup>
 

--- a/src/JellyFederation.Plugin/PluginServiceRegistrator.cs
+++ b/src/JellyFederation.Plugin/PluginServiceRegistrator.cs
@@ -23,6 +23,8 @@ public class PluginServiceRegistrator : IPluginServiceRegistrator
 
         services.AddHttpClient<LibrarySyncService>();
         services.AddSingleton<HolePunchService>();
+        services.AddSingleton<WebRtcTransportService>();
+        services.AddSingleton<LocalStreamEndpoint>();
         // Use AddHttpClient so the DI container manages HttpClient lifetime via IHttpClientFactory,
         // avoiding socket exhaustion from a long-lived singleton HttpClient.
         services.AddHttpClient<FileTransferService>();

--- a/src/JellyFederation.Plugin/Services/FederationSignalRService.Logging.cs
+++ b/src/JellyFederation.Plugin/Services/FederationSignalRService.Logging.cs
@@ -60,4 +60,25 @@ public partial class FederationSignalRService
 
     [LoggerMessage(11, LogLevel.Information, "Connected to federation server at {Url}")]
     private static partial void LogConnected(ILogger logger, string url);
+
+    [LoggerMessage(13, LogLevel.Information,
+        "IceNegotiateStart received for request {FileRequestId} as {Role}")]
+    private static partial void LogIceNegotiateStart(ILogger logger, Guid fileRequestId, string role);
+
+    [LoggerMessage(14, LogLevel.Error, "IceNegotiateStart handling failed for request {FileRequestId}")]
+    private static partial void LogIceNegotiateStartFailed(ILogger logger, Exception ex, Guid fileRequestId);
+
+    [LoggerMessage(15, LogLevel.Debug, "IceSignal received for request {FileRequestId}: type={Type}")]
+    private static partial void LogIceSignalReceived(ILogger logger, Guid fileRequestId, string type);
+
+    [LoggerMessage(16, LogLevel.Debug,
+        "Relay chunk received for request {FileRequestId}: index={ChunkIndex}, isEof={IsEof}")]
+    private static partial void LogRelayChunkReceived(ILogger logger, Guid fileRequestId, long chunkIndex,
+        bool isEof);
+
+    [LoggerMessage(17, LogLevel.Information, "RelayTransferStart received for request {FileRequestId}")]
+    private static partial void LogRelayTransferStartReceived(ILogger logger, Guid fileRequestId);
+
+    [LoggerMessage(18, LogLevel.Error, "RelayTransferStart handling failed for request {FileRequestId}")]
+    private static partial void LogRelayTransferStartFailed(ILogger logger, Exception ex, Guid fileRequestId);
 }

--- a/src/JellyFederation.Plugin/Services/FederationSignalRService.cs
+++ b/src/JellyFederation.Plugin/Services/FederationSignalRService.cs
@@ -15,6 +15,7 @@ public partial class FederationSignalRService : IAsyncDisposable
 {
     private readonly IPluginConfigurationProvider _configProvider;
     private readonly HolePunchService _holePunch;
+    private readonly WebRtcTransportService _webRtc;
     private readonly LibrarySyncService _librarySync;
     private readonly ILogger<FederationSignalRService> _logger;
     private HubConnection? _connection;
@@ -25,11 +26,13 @@ public partial class FederationSignalRService : IAsyncDisposable
     /// </summary>
     public FederationSignalRService(ILogger<FederationSignalRService> logger,
         HolePunchService holePunch,
+        WebRtcTransportService webRtc,
         LibrarySyncService librarySync,
         IPluginConfigurationProvider configProvider)
     {
         _logger = logger;
         _holePunch = holePunch;
+        _webRtc = webRtc;
         _librarySync = librarySync;
         _configProvider = configProvider;
     }
@@ -108,6 +111,59 @@ public partial class FederationSignalRService : IAsyncDisposable
         {
             LogCancellingTransfer(_logger, msg.FileRequestId);
             _holePunch.Cancel(msg.FileRequestId);
+            _webRtc.Cancel(msg.FileRequestId);
+        });
+
+        _connection.On<IceNegotiateStart>("IceNegotiateStart", async msg =>
+        {
+            LogIceNegotiateStart(_logger, msg.FileRequestId, msg.Role.ToString());
+            var cfg = _configProvider.GetConfiguration();
+            try
+            {
+                if (msg.Role == IceRole.Offerer)
+                {
+                    // Sender side: we need the jellyfinItemId — retrieve it from the pending sockets dict
+                    // via HolePunchService (which stored it during PrepareAndSignalReadyAsync).
+                    // Fall back to empty string if not found; BeginAsOffererAsync will log the resolution error.
+                    var jellyfinItemId = _holePunch.GetPendingJellyfinItemId(msg.FileRequestId) ?? string.Empty;
+                    await _webRtc.BeginAsOffererAsync(msg.FileRequestId, jellyfinItemId, _connection!, cfg)
+                        .ConfigureAwait(false);
+                }
+                else
+                {
+                    await _webRtc.BeginAsAnswererAsync(msg.FileRequestId, _connection!, cfg)
+                        .ConfigureAwait(false);
+                }
+            }
+            catch (Exception ex)
+            {
+                LogIceNegotiateStartFailed(_logger, ex, msg.FileRequestId);
+            }
+        });
+
+        _connection.On<IceSignal>("IceSignal", msg =>
+        {
+            LogIceSignalReceived(_logger, msg.FileRequestId, msg.Type.ToString());
+            _webRtc.HandleIceSignal(msg);
+        });
+
+        _connection.On<RelayChunk>("RelayReceiveChunk", msg =>
+        {
+            LogRelayChunkReceived(_logger, msg.FileRequestId, msg.ChunkIndex, msg.IsEof);
+            _webRtc.EnqueueRelayChunk(msg);
+        });
+
+        _connection.On<RelayTransferStart>("RelayTransferStart", async msg =>
+        {
+            LogRelayTransferStartReceived(_logger, msg.FileRequestId);
+            try
+            {
+                await _webRtc.StartRelayReceiveModeAsync(msg, _connection!).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                LogRelayTransferStartFailed(_logger, ex, msg.FileRequestId);
+            }
         });
 
         _connection.Reconnecting += _ =>

--- a/src/JellyFederation.Plugin/Services/FileTransferService.Logging.cs
+++ b/src/JellyFederation.Plugin/Services/FileTransferService.Logging.cs
@@ -112,4 +112,8 @@ public partial class FileTransferService
         string code,
         string category,
         string message);
+
+    [LoggerMessage(27, LogLevel.Information,
+        "DataChannel streaming receive started for request {FileRequestId}")]
+    private static partial void LogStreamingReceiveStarted(ILogger logger, Guid fileRequestId);
 }

--- a/src/JellyFederation.Plugin/Services/FileTransferService.cs
+++ b/src/JellyFederation.Plugin/Services/FileTransferService.cs
@@ -7,7 +7,10 @@ using System.Net.Sockets;
 using System.Security.Authentication;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using System.IO.Pipelines;
+using System.Text;
 using System.Text.Json;
+using System.Threading.Channels;
 using JellyFederation.Plugin.Configuration;
 using JellyFederation.Shared.Models;
 using JellyFederation.Shared.SignalR;
@@ -15,6 +18,7 @@ using JellyFederation.Shared.Telemetry;
 using MediaBrowser.Controller.Library;
 using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.Extensions.Logging;
+using SIPSorcery.Net;
 
 namespace JellyFederation.Plugin.Services;
 
@@ -43,6 +47,10 @@ public partial class FileTransferService
     // Active transfer cancellation tokens keyed by fileRequestId
     private readonly ConcurrentDictionary<Guid, CancellationTokenSource>
         _activeCts = new();
+
+    // Relay chunk queues keyed by fileRequestId — populated by SignalR handler, drained by ReceiveRelayAsync
+    private readonly ConcurrentDictionary<Guid, Channel<RelayChunk>>
+        _relayQueues = new();
 
     private readonly IPluginConfigurationProvider _configProvider;
     private readonly HttpClient _http;
@@ -805,6 +813,407 @@ public partial class FileTransferService
         }
 
         throw new IOException($"Failed to get ACK for seq {seq} after {MaxRetries} attempts");
+    }
+
+    /// <summary>
+    ///     Sends a file over an open WebRTC DataChannel.
+    ///     Protocol: text header JSON → binary chunks → binary EofMagic.
+    /// </summary>
+    public async Task SendDataChannelAsync(
+        Guid fileRequestId,
+        string jellyfinItemId,
+        RTCDataChannel dc,
+        PluginConfiguration config,
+        CancellationToken ct)
+    {
+        var correlationId = FederationTelemetry.CreateCorrelationId();
+        var fileResolution = ResolveSourceFile(jellyfinItemId, correlationId);
+        if (fileResolution.IsFailure)
+        {
+            LogOperationFailureDescriptor(_logger, fileRequestId,
+                fileResolution.Failure!.Code, fileResolution.Failure.Category.ToString(), fileResolution.Failure.Message);
+            return;
+        }
+
+        var fileInfo = fileResolution.RequireValue();
+        LogSendingFile(_logger, fileInfo.Name, fileInfo.Length, new System.Net.IPEndPoint(0, 0));
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        _activeCts[fileRequestId] = cts;
+        try
+        {
+            // Header as text so receiver can distinguish it from binary chunks
+            var headerJson = JsonSerializer.Serialize(new FileHeader(fileInfo.Name, fileInfo.Length));
+            dc.send(headerJson);
+
+            var fs = fileInfo.OpenRead();
+            await using var fs1 = fs.ConfigureAwait(false);
+            var buffer = new byte[ChunkSize];
+            int bytesRead;
+            while ((bytesRead = await fs.ReadAsync(buffer, cts.Token).ConfigureAwait(false)) > 0)
+            {
+                cts.Token.ThrowIfCancellationRequested();
+                dc.send(buffer[..bytesRead]);
+            }
+
+            dc.send(EofMagic);
+            LogFileSent(_logger, fileInfo.Name);
+            FederationMetrics.RecordOperation("file.transfer.send.webrtc", "plugin",
+                FederationTelemetry.OutcomeSuccess, TimeSpan.Zero, FederationPlugin.ReleaseVersion);
+        }
+        catch (OperationCanceledException)
+        {
+            LogSendCancelled(_logger, fileRequestId);
+        }
+        finally
+        {
+            _activeCts.TryRemove(fileRequestId, out _);
+        }
+    }
+
+    /// <summary>
+    ///     Receives a file over an open WebRTC DataChannel and writes it to the download directory.
+    /// </summary>
+    public async Task ReceiveDataChannelAsync(
+        Guid fileRequestId,
+        RTCDataChannel dc,
+        PluginConfiguration config,
+        HubConnection connection,
+        CancellationToken ct)
+    {
+        var correlationId = FederationTelemetry.CreateCorrelationId();
+
+        if (string.IsNullOrEmpty(config.DownloadDirectory))
+        {
+            LogDownloadDirNotConfigured(_logger);
+            return;
+        }
+
+        Directory.CreateDirectory(config.DownloadDirectory);
+
+        // Bridge the DataChannel onmessage callback into an async-friendly channel.
+        // Protocol param is ignored — we distinguish header (first message = UTF-8 JSON)
+        // from chunks (binary) and EOF (EofMagic) by position and content.
+        var pipe = Channel.CreateUnbounded<byte[]>(new UnboundedChannelOptions { SingleReader = true });
+        dc.onmessage += (_, _, data) => pipe.Writer.TryWrite(data);
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        _activeCts[fileRequestId] = cts;
+
+        string? filePath = null;
+        FileStream? fs = null;
+        var receivedEof = false;
+        long totalBytes = 0;
+        long bytesReceived = 0;
+        var lastProgressReport = DateTime.UtcNow;
+
+        try
+        {
+            // First message is always the JSON header (UTF-8 encoded, sent as text or binary)
+            var headerBytes = await pipe.Reader.ReadAsync(cts.Token).ConfigureAwait(false);
+            var header = JsonSerializer.Deserialize<FileHeader>(Encoding.UTF8.GetString(headerBytes));
+            if (header is null) return;
+
+            filePath = GetUniqueFilePath(Path.Combine(config.DownloadDirectory, header.FileName));
+            fs = File.Create(filePath);
+            totalBytes = header.FileSize;
+            LogReceivingFile(_logger, header.FileName, header.FileSize, filePath);
+
+            while (true)
+            {
+                var data = await pipe.Reader.ReadAsync(cts.Token).ConfigureAwait(false);
+
+                if (data.Length == EofMagic.Length && data.AsSpan().SequenceEqual(EofMagic))
+                {
+                    LogReceivedEof(_logger);
+                    if (totalBytes > 0)
+                        await ReportProgressAsync(connection, fileRequestId, totalBytes, totalBytes)
+                            .ConfigureAwait(false);
+                    receivedEof = true;
+                    break;
+                }
+
+                await fs.WriteAsync(data, cts.Token).ConfigureAwait(false);
+                bytesReceived += data.Length;
+
+                if (totalBytes > 0 && (DateTime.UtcNow - lastProgressReport).TotalSeconds >= 1)
+                {
+                    lastProgressReport = DateTime.UtcNow;
+                    await ReportProgressAsync(connection, fileRequestId, bytesReceived, totalBytes)
+                        .ConfigureAwait(false);
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            LogReceiveCancelled(_logger, fileRequestId);
+        }
+        finally
+        {
+            _activeCts.TryRemove(fileRequestId, out _);
+            pipe.Writer.TryComplete();
+
+            if (fs is not null)
+            {
+                await fs.FlushAsync(CancellationToken.None).ConfigureAwait(false);
+                await fs.DisposeAsync().ConfigureAwait(false);
+            }
+
+            if (!receivedEof && filePath is not null && File.Exists(filePath))
+                try
+                {
+                    File.Delete(filePath);
+                    LogDeletedIncompleteFile(_logger, filePath);
+                }
+                catch (Exception ex)
+                {
+                    LogCouldNotDeleteIncompleteFile(_logger, ex, filePath);
+                }
+        }
+
+        if (receivedEof && filePath is not null && File.Exists(filePath))
+        {
+            LogFileSaved(_logger, filePath);
+            TriggerLibraryScan(filePath, config.DownloadDirectory);
+            await MarkCompleteAsync(fileRequestId, correlationId, CancellationToken.None).ConfigureAwait(false);
+            FederationMetrics.RecordOperation("file.transfer.receive.webrtc", "plugin",
+                FederationTelemetry.OutcomeSuccess, TimeSpan.Zero, FederationPlugin.ReleaseVersion);
+        }
+    }
+
+    /// <summary>
+    ///     Sends a file as relay chunks through the federation server when direct ICE fails.
+    /// </summary>
+    public async Task SendRelayAsync(
+        Guid fileRequestId,
+        string jellyfinItemId,
+        HubConnection connection,
+        PluginConfiguration config,
+        CancellationToken ct)
+    {
+        var correlationId = FederationTelemetry.CreateCorrelationId();
+        var fileResolution = ResolveSourceFile(jellyfinItemId, correlationId);
+        if (fileResolution.IsFailure)
+        {
+            LogOperationFailureDescriptor(_logger, fileRequestId,
+                fileResolution.Failure!.Code, fileResolution.Failure.Category.ToString(), fileResolution.Failure.Message);
+            return;
+        }
+
+        var fileInfo = fileResolution.RequireValue();
+        LogSendingFile(_logger, fileInfo.Name, fileInfo.Length, new System.Net.IPEndPoint(0, 0));
+
+        try
+        {
+            var fs = fileInfo.OpenRead();
+            await using var fs1 = fs.ConfigureAwait(false);
+            var buffer = new byte[ChunkSize];
+            int bytesRead;
+            long chunkIndex = 0;
+
+            while ((bytesRead = await fs.ReadAsync(buffer, ct).ConfigureAwait(false)) > 0)
+            {
+                ct.ThrowIfCancellationRequested();
+                await connection.SendAsync("RelaySendChunk",
+                    new RelayChunk(fileRequestId, chunkIndex, false, buffer[..bytesRead]),
+                    ct).ConfigureAwait(false);
+                chunkIndex++;
+            }
+
+            // EOF marker
+            await connection.SendAsync("RelaySendChunk",
+                new RelayChunk(fileRequestId, chunkIndex, true, []),
+                ct).ConfigureAwait(false);
+
+            LogFileSent(_logger, fileInfo.Name);
+            FederationMetrics.RecordOperation("file.transfer.send.relay", "plugin",
+                FederationTelemetry.OutcomeSuccess, TimeSpan.Zero, FederationPlugin.ReleaseVersion);
+        }
+        catch (OperationCanceledException)
+        {
+            LogSendCancelled(_logger, fileRequestId);
+        }
+    }
+
+    /// <summary>
+    ///     Receives relay chunks forwarded from the federation server and writes to disk.
+    ///     Chunks are delivered via <see cref="EnqueueRelayChunk"/> from the SignalR handler.
+    /// </summary>
+    public async Task ReceiveRelayAsync(
+        Guid fileRequestId,
+        HubConnection connection,
+        PluginConfiguration config,
+        CancellationToken ct)
+    {
+        var correlationId = FederationTelemetry.CreateCorrelationId();
+
+        if (string.IsNullOrEmpty(config.DownloadDirectory))
+        {
+            LogDownloadDirNotConfigured(_logger);
+            return;
+        }
+
+        Directory.CreateDirectory(config.DownloadDirectory);
+
+        var queue = Channel.CreateUnbounded<RelayChunk>(new UnboundedChannelOptions { SingleReader = true });
+        _relayQueues[fileRequestId] = queue;
+
+        string? filePath = null;
+        FileStream? fs = null;
+        var receivedEof = false;
+        long totalBytes = 0;
+        long bytesReceived = 0;
+
+        try
+        {
+            // First chunk carries the file header JSON in its Data field as a special convention:
+            // relay doesn't have a separate header frame — the sender prepends file info in the
+            // first chunk (Data = JSON bytes of FileHeader, ChunkIndex = -1).
+            // For the relay path we wait for a header chunk first.
+            var firstChunk = await queue.Reader.ReadAsync(ct).ConfigureAwait(false);
+            if (firstChunk.ChunkIndex == -1)
+            {
+                var header = JsonSerializer.Deserialize<FileHeader>(firstChunk.Data);
+                if (header is null) return;
+                filePath = GetUniqueFilePath(Path.Combine(config.DownloadDirectory, header.FileName));
+                fs = File.Create(filePath);
+                totalBytes = header.FileSize;
+                LogReceivingFile(_logger, header.FileName, header.FileSize, filePath);
+            }
+            else
+            {
+                // No header chunk — create a temp file name
+                filePath = GetUniqueFilePath(Path.Combine(config.DownloadDirectory, $"relay-{fileRequestId}"));
+                fs = File.Create(filePath);
+                if (!firstChunk.IsEof)
+                {
+                    await fs.WriteAsync(firstChunk.Data, ct).ConfigureAwait(false);
+                    bytesReceived += firstChunk.Data.Length;
+                }
+                else
+                {
+                    receivedEof = true;
+                }
+            }
+
+            while (!receivedEof)
+            {
+                var chunk = await queue.Reader.ReadAsync(ct).ConfigureAwait(false);
+                if (chunk.IsEof)
+                {
+                    receivedEof = true;
+                    if (totalBytes > 0)
+                        await ReportProgressAsync(connection, fileRequestId, totalBytes, totalBytes)
+                            .ConfigureAwait(false);
+                    break;
+                }
+
+                if (fs is not null)
+                    await fs.WriteAsync(chunk.Data, ct).ConfigureAwait(false);
+                bytesReceived += chunk.Data.Length;
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            LogReceiveCancelled(_logger, fileRequestId);
+        }
+        finally
+        {
+            _relayQueues.TryRemove(fileRequestId, out _);
+
+            if (fs is not null)
+            {
+                await fs.FlushAsync(CancellationToken.None).ConfigureAwait(false);
+                await fs.DisposeAsync().ConfigureAwait(false);
+            }
+
+            if (!receivedEof && filePath is not null && File.Exists(filePath))
+                try
+                {
+                    File.Delete(filePath);
+                    LogDeletedIncompleteFile(_logger, filePath);
+                }
+                catch (Exception ex)
+                {
+                    LogCouldNotDeleteIncompleteFile(_logger, ex, filePath);
+                }
+        }
+
+        if (receivedEof && filePath is not null && File.Exists(filePath))
+        {
+            LogFileSaved(_logger, filePath);
+            TriggerLibraryScan(filePath, config.DownloadDirectory);
+            await MarkCompleteAsync(fileRequestId, correlationId, CancellationToken.None).ConfigureAwait(false);
+            FederationMetrics.RecordOperation("file.transfer.receive.relay", "plugin",
+                FederationTelemetry.OutcomeSuccess, TimeSpan.Zero, FederationPlugin.ReleaseVersion);
+        }
+    }
+
+    /// <summary>
+    ///     Receives DataChannel data and writes it into a <see cref="PipeWriter"/>.
+    ///     Does NOT write to disk and does NOT trigger a library scan — intended for streaming playback.
+    /// </summary>
+    /// <returns>
+    ///     The <see cref="PipeReader"/> end of the pipe; the caller passes this to
+    ///     <see cref="LocalStreamEndpoint"/> to serve over HTTP.
+    /// </returns>
+    public PipeReader ReceiveStreamingAsync(Guid fileRequestId, RTCDataChannel dc, CancellationToken ct)
+    {
+        var pipe = new Pipe();
+
+        dc.onmessage += (_, _, data) =>
+        {
+            // Skip header and EOF frames — just stream raw bytes to the pipe
+            if (data.Length == EofMagic.Length && data.AsSpan().SequenceEqual(EofMagic))
+            {
+                pipe.Writer.Complete();
+                return;
+            }
+
+            // Skip the first (header) message — it's JSON, not media data
+            // We detect it by checking if it starts with '{' (valid JSON header)
+            if (data.Length > 0 && data[0] == (byte)'{')
+                return;
+
+            var mem = pipe.Writer.GetMemory(data.Length);
+            data.CopyTo(mem);
+            pipe.Writer.Advance(data.Length);
+            _ = pipe.Writer.FlushAsync(ct).AsTask();
+        };
+
+        ct.Register(() => pipe.Writer.Complete(new OperationCanceledException(ct)));
+        LogStreamingReceiveStarted(_logger, fileRequestId);
+        return pipe.Reader;
+    }
+
+    /// <summary>
+    ///     Called by the SignalR handler to deliver a relay chunk to the waiting ReceiveRelayAsync loop.
+    /// </summary>
+    public void EnqueueRelayChunk(RelayChunk chunk)
+    {
+        if (_relayQueues.TryGetValue(chunk.FileRequestId, out var queue))
+            queue.Writer.TryWrite(chunk);
+    }
+
+    private async Task MarkCompleteAsync(Guid fileRequestId, string correlationId, CancellationToken ct)
+    {
+        var cfg = _configProvider.GetConfiguration();
+        var req = new HttpRequestMessage(
+            HttpMethod.Put,
+            $"{cfg.FederationServerUrl.TrimEnd('/')}/api/filerequests/{fileRequestId}/complete");
+        req.Headers.Add("X-Api-Key", cfg.ApiKey);
+        TraceContextPropagation.InjectToHttpRequest(req);
+        TraceContextPropagation.InjectCorrelationId(req.Headers, correlationId);
+        try
+        {
+            var resp = await _http.SendAsync(req, ct).ConfigureAwait(false);
+            if (!resp.IsSuccessStatusCode)
+                LogMarkCompleteFailed(_logger, fileRequestId, resp.StatusCode);
+        }
+        catch (Exception ex)
+        {
+            LogNotifyCompletionFailed(_logger, ex, fileRequestId);
+        }
     }
 
     private record FileHeader

--- a/src/JellyFederation.Plugin/Services/HolePunchService.cs
+++ b/src/JellyFederation.Plugin/Services/HolePunchService.cs
@@ -110,7 +110,8 @@ public partial class HolePunchService
             localPort,
             overrideIp ?? "(auto)");
         await connection.SendAsync("ReportHolePunchReady",
-                new HolePunchReady(notification.FileRequestId, localPort, overrideIp, supportsQuic, threshold))
+                new HolePunchReady(notification.FileRequestId, localPort, overrideIp, supportsQuic, threshold,
+                    SupportsIce: true))
             .ConfigureAwait(false);
     }
 
@@ -361,6 +362,14 @@ public partial class HolePunchService
             LogInvalidProbe(_logger, received);
         }
     }
+
+    /// <summary>
+    ///     Returns the Jellyfin item ID stored during PrepareAndSignalReadyAsync,
+    ///     or null if no pending socket exists for this request.
+    ///     Used by the ICE path to hand off the item ID without consuming the socket entry.
+    /// </summary>
+    public string? GetPendingJellyfinItemId(Guid fileRequestId) =>
+        _pendingSockets.TryGetValue(fileRequestId, out var pending) ? pending.JellyfinItemId : null;
 
     public void Cancel(Guid fileRequestId)
     {

--- a/src/JellyFederation.Plugin/Services/LocalStreamEndpoint.cs
+++ b/src/JellyFederation.Plugin/Services/LocalStreamEndpoint.cs
@@ -1,0 +1,119 @@
+using System.Collections.Concurrent;
+using System.IO.Pipelines;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace JellyFederation.Plugin.Services;
+
+/// <summary>
+///     Hosts a minimal localhost-only HTTP server for WebRTC streaming playback.
+///     Jellyfin can play a <c>http://127.0.0.1:{port}/stream/{token}</c> URL directly.
+///     Each token maps to a <see cref="PipeReader"/> whose data is piped into the HTTP response.
+///     The server auto-cleans up a stream registration when the pipe completes.
+/// </summary>
+public sealed class LocalStreamEndpoint : IAsyncDisposable
+{
+    private readonly ConcurrentDictionary<Guid, PipeReader> _streams = new();
+    private readonly ILogger<LocalStreamEndpoint> _logger;
+    private WebApplication? _app;
+    private int _port;
+
+    public LocalStreamEndpoint(ILogger<LocalStreamEndpoint> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <summary>
+    ///     Starts the Kestrel listener on an OS-assigned port (first call only).
+    ///     Subsequent calls are no-ops.
+    /// </summary>
+    public async Task EnsureStartedAsync(CancellationToken ct = default)
+    {
+        if (_app is not null) return;
+
+        var builder = WebApplication.CreateSlimBuilder();
+        builder.WebHost.ConfigureKestrel(k => k.ListenLocalhost(0)); // port 0 = OS assigns
+        builder.Logging.ClearProviders(); // use Jellyfin's logging, not a second pipeline
+
+        _app = builder.Build();
+        _app.MapGet("/stream/{token:guid}", ServeStreamAsync);
+
+        await _app.StartAsync(ct).ConfigureAwait(false);
+
+        // Resolve the OS-assigned port
+        var addresses = _app.Urls;
+        foreach (var addr in addresses)
+        {
+            if (Uri.TryCreate(addr, UriKind.Absolute, out var uri))
+            {
+                _port = uri.Port;
+                break;
+            }
+        }
+
+        _logger.LogInformation("LocalStreamEndpoint listening on http://127.0.0.1:{Port}", _port);
+    }
+
+    /// <summary>
+    ///     Registers a <see cref="PipeReader"/> for the given token and returns the URL
+    ///     Jellyfin should play.
+    /// </summary>
+    public async Task<string> RegisterStreamAsync(Guid token, PipeReader source, CancellationToken ct = default)
+    {
+        await EnsureStartedAsync(ct).ConfigureAwait(false);
+        _streams[token] = source;
+        return $"http://127.0.0.1:{_port}/stream/{token}";
+    }
+
+    /// <summary>
+    ///     Returns the streaming URL for a registered token without starting a stream.
+    ///     Returns null if the token is not registered.
+    /// </summary>
+    public string? GetStreamUrl(Guid token) =>
+        _streams.ContainsKey(token) ? $"http://127.0.0.1:{_port}/stream/{token}" : null;
+
+    private async Task ServeStreamAsync(HttpContext context, Guid token)
+    {
+        if (!_streams.TryGetValue(token, out var reader))
+        {
+            context.Response.StatusCode = StatusCodes.Status404NotFound;
+            return;
+        }
+
+        context.Response.ContentType = "application/octet-stream";
+
+        try
+        {
+            while (true)
+            {
+                var result = await reader.ReadAsync(context.RequestAborted).ConfigureAwait(false);
+                var buffer = result.Buffer;
+
+                foreach (var segment in buffer)
+                    await context.Response.Body.WriteAsync(segment, context.RequestAborted).ConfigureAwait(false);
+
+                reader.AdvanceTo(buffer.End);
+
+                if (result.IsCompleted || result.IsCanceled) break;
+            }
+
+            await context.Response.Body.FlushAsync(context.RequestAborted).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Client disconnected — normal for streaming
+        }
+        finally
+        {
+            _streams.TryRemove(token, out _);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_app is not null)
+            await _app.DisposeAsync().ConfigureAwait(false);
+    }
+}

--- a/src/JellyFederation.Plugin/Services/WebRtcTransportService.Logging.cs
+++ b/src/JellyFederation.Plugin/Services/WebRtcTransportService.Logging.cs
@@ -1,0 +1,76 @@
+using JellyFederation.Shared.Models;
+using JellyFederation.Shared.SignalR;
+using Microsoft.Extensions.Logging;
+
+namespace JellyFederation.Plugin.Services;
+
+public partial class WebRtcTransportService
+{
+    [LoggerMessage(1, LogLevel.Information, "ICE negotiation starting as Offerer for request {FileRequestId}")]
+    private static partial void LogBeginAsOfferer(ILogger logger, Guid fileRequestId);
+
+    [LoggerMessage(2, LogLevel.Information, "ICE negotiation starting as Answerer for request {FileRequestId}")]
+    private static partial void LogBeginAsAnswerer(ILogger logger, Guid fileRequestId);
+
+    [LoggerMessage(3, LogLevel.Information,
+        "DataChannel opened for request {FileRequestId} (role={Role})")]
+    private static partial void LogDataChannelOpen(ILogger logger, Guid fileRequestId, IceRole role);
+
+    [LoggerMessage(4, LogLevel.Information, "DataChannel closed for request {FileRequestId}")]
+    private static partial void LogDataChannelClosed(ILogger logger, Guid fileRequestId);
+
+    [LoggerMessage(5, LogLevel.Information,
+        "ICE connection state changed for request {FileRequestId}: {State}")]
+    private static partial void LogIceStateChanged(ILogger logger, Guid fileRequestId, string state);
+
+    [LoggerMessage(6, LogLevel.Debug, "SDP offer created for request {FileRequestId}")]
+    private static partial void LogSdpOfferCreated(ILogger logger, Guid fileRequestId);
+
+    [LoggerMessage(7, LogLevel.Debug, "SDP answer created for request {FileRequestId}")]
+    private static partial void LogSdpAnswerCreated(ILogger logger, Guid fileRequestId);
+
+    [LoggerMessage(8, LogLevel.Debug, "SDP answer applied (remote description set) for request {FileRequestId}")]
+    private static partial void LogSdpAnswerApplied(ILogger logger, Guid fileRequestId);
+
+    [LoggerMessage(9, LogLevel.Debug, "Waiting for SDP offer to arrive for request {FileRequestId}")]
+    private static partial void LogWaitingForOffer(ILogger logger, Guid fileRequestId);
+
+    [LoggerMessage(10, LogLevel.Information,
+        "DataChannel received from offerer for request {FileRequestId}")]
+    private static partial void LogDataChannelReceived(ILogger logger, Guid fileRequestId);
+
+    [LoggerMessage(11, LogLevel.Warning,
+        "ICE signal {Type} arrived but no session found for request {FileRequestId} — dropping")]
+    private static partial void LogIceSignalNoSession(ILogger logger, Guid fileRequestId, string type);
+
+    [LoggerMessage(12, LogLevel.Warning,
+        "ICE negotiation timed out (30 s) for request {FileRequestId}")]
+    private static partial void LogIceTimeout(ILogger logger, Guid fileRequestId);
+
+    [LoggerMessage(13, LogLevel.Debug,
+        "Trickle ICE candidate forwarded for request {FileRequestId}")]
+    private static partial void LogCandidateForwarded(ILogger logger, Guid fileRequestId);
+
+    [LoggerMessage(14, LogLevel.Warning,
+        "Failed to forward ICE candidate for request {FileRequestId}")]
+    private static partial void LogCandidateForwardFailed(ILogger logger, Exception ex, Guid fileRequestId);
+
+    [LoggerMessage(15, LogLevel.Warning,
+        "Failed to add remote ICE candidate for request {FileRequestId}")]
+    private static partial void LogIceCandidateAddFailed(ILogger logger, Exception ex, Guid fileRequestId);
+
+    [LoggerMessage(16, LogLevel.Warning,
+        "ICE failed — engaging relay fallback for request {FileRequestId}")]
+    private static partial void LogRelayFallbackEngaged(ILogger logger, Guid fileRequestId);
+
+    [LoggerMessage(17, LogLevel.Warning,
+        "ICE failed — switching to relay receive mode for request {FileRequestId}")]
+    private static partial void LogRelayReceiveModeEngaged(ILogger logger, Guid fileRequestId);
+
+    [LoggerMessage(18, LogLevel.Warning,
+        "Failed to notify peer of relay start for request {FileRequestId}")]
+    private static partial void LogRelayNotifyFailed(ILogger logger, Exception ex, Guid fileRequestId);
+
+    [LoggerMessage(19, LogLevel.Debug, "ICE session cleaned up for request {FileRequestId}")]
+    private static partial void LogSessionCleaned(ILogger logger, Guid fileRequestId);
+}

--- a/src/JellyFederation.Plugin/Services/WebRtcTransportService.cs
+++ b/src/JellyFederation.Plugin/Services/WebRtcTransportService.cs
@@ -1,0 +1,481 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Text.Json;
+using JellyFederation.Plugin.Configuration;
+using JellyFederation.Shared.Models;
+using JellyFederation.Shared.SignalR;
+using JellyFederation.Shared.Telemetry;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.Logging;
+using SIPSorcery.Net;
+
+namespace JellyFederation.Plugin.Services;
+
+/// <summary>
+///     Manages WebRTC ICE negotiation and DataChannel file transfer sessions.
+///     Replaces the UDP hole-punch path when both peers advertise SupportsIce=true.
+///     The existing HolePunchService is retained unchanged for backward-compat peers.
+/// </summary>
+public partial class WebRtcTransportService
+{
+    private const int IceTimeoutMs = 30_000;
+    private const string DataChannelLabel = "transfer";
+
+    private readonly ConcurrentDictionary<Guid, IceNegotiationSession> _sessions = new();
+    private readonly FileTransferService _fileTransfer;
+    private readonly LocalStreamEndpoint _streamEndpoint;
+    private readonly IPluginConfigurationProvider _configProvider;
+    private readonly ILogger<WebRtcTransportService> _logger;
+
+    public WebRtcTransportService(
+        FileTransferService fileTransfer,
+        LocalStreamEndpoint streamEndpoint,
+        IPluginConfigurationProvider configProvider,
+        ILogger<WebRtcTransportService> logger)
+    {
+        _fileTransfer = fileTransfer;
+        _streamEndpoint = streamEndpoint;
+        _configProvider = configProvider;
+        _logger = logger;
+    }
+
+    /// <summary>
+    ///     Called when server sends IceNegotiateStart with Role=Offerer (sender peer).
+    ///     Creates RTCPeerConnection, creates DataChannel, generates SDP offer, starts trickle candidates.
+    /// </summary>
+    public async Task BeginAsOffererAsync(
+        Guid fileRequestId,
+        string jellyfinItemId,
+        HubConnection connection,
+        PluginConfiguration config)
+    {
+        LogBeginAsOfferer(_logger, fileRequestId);
+        using var activity = FederationTelemetry.PluginActivitySource.StartActivity(
+            "ice.negotiate.offerer", ActivityKind.Client);
+
+        var pc = CreatePeerConnection(config);
+        using var cts = new CancellationTokenSource(IceTimeoutMs);
+        var session = new IceNegotiationSession(fileRequestId, pc, IceRole.Offerer, cts);
+        _sessions[fileRequestId] = session;
+
+        // Wire up trickle candidate forwarding
+        pc.onicecandidate += candidate =>
+        {
+            if (candidate is null) return;
+            var payload = JsonSerializer.Serialize(new
+            {
+                candidate = candidate.candidate,
+                sdpMid = candidate.sdpMid,
+                sdpMLineIndex = candidate.sdpMLineIndex
+            });
+            _ = ForwardCandidateAsync(connection, fileRequestId, payload, cts.Token);
+        };
+
+        // Create the data channel before the offer so it appears in the SDP
+        var dc = await pc.createDataChannel(DataChannelLabel).ConfigureAwait(false);
+        session.DataChannel = dc;
+
+        dc.onopen += () =>
+        {
+            LogDataChannelOpen(_logger, fileRequestId, IceRole.Offerer);
+            session.State = IceSessionState.Connected;
+            _ = Task.Run(() => _fileTransfer.SendDataChannelAsync(fileRequestId, jellyfinItemId, dc, config, cts.Token));
+        };
+        dc.onclose += () => LogDataChannelClosed(_logger, fileRequestId);
+
+        // ICE connection state changes
+        pc.onconnectionstatechange += state =>
+        {
+            LogIceStateChanged(_logger, fileRequestId, state.ToString());
+            if (state == RTCPeerConnectionState.failed || state == RTCPeerConnectionState.disconnected)
+                _ = TriggerRelayFallbackAsync(fileRequestId, jellyfinItemId, connection, config, cts.Token);
+        };
+
+        var offer = pc.createOffer();
+        await pc.setLocalDescription(offer).ConfigureAwait(false);
+        LogSdpOfferCreated(_logger, fileRequestId);
+
+        await connection.SendAsync("ForwardIceSignal",
+            new IceSignal(fileRequestId, IceSignalType.Offer, offer.sdp),
+            cts.Token).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///     Called when server sends IceNegotiateStart with Role=Answerer (receiver peer).
+    ///     Creates RTCPeerConnection, waits for offer, creates SDP answer, starts trickle candidates.
+    /// </summary>
+    public async Task BeginAsAnswererAsync(
+        Guid fileRequestId,
+        HubConnection connection,
+        PluginConfiguration config)
+    {
+        LogBeginAsAnswerer(_logger, fileRequestId);
+        using var activity = FederationTelemetry.PluginActivitySource.StartActivity(
+            "ice.negotiate.answerer", ActivityKind.Client);
+
+        var pc = CreatePeerConnection(config);
+        using var cts = new CancellationTokenSource(IceTimeoutMs);
+        var offerTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var session = new IceNegotiationSession(fileRequestId, pc, IceRole.Answerer, cts)
+        {
+            OfferTcs = offerTcs
+        };
+        _sessions[fileRequestId] = session;
+
+        // Wire up trickle candidate forwarding
+        pc.onicecandidate += candidate =>
+        {
+            if (candidate is null) return;
+            var payload = JsonSerializer.Serialize(new
+            {
+                candidate = candidate.candidate,
+                sdpMid = candidate.sdpMid,
+                sdpMLineIndex = candidate.sdpMLineIndex
+            });
+            _ = ForwardCandidateAsync(connection, fileRequestId, payload, cts.Token);
+        };
+
+        // Data channel arrives from offerer
+        pc.ondatachannel += dc =>
+        {
+            session.DataChannel = dc;
+            LogDataChannelReceived(_logger, fileRequestId);
+
+            dc.onopen += () =>
+            {
+                LogDataChannelOpen(_logger, fileRequestId, IceRole.Answerer);
+                session.State = IceSessionState.Connected;
+                _ = Task.Run(() => _fileTransfer.ReceiveDataChannelAsync(fileRequestId, dc, config, connection, cts.Token));
+            };
+            dc.onclose += () => LogDataChannelClosed(_logger, fileRequestId);
+        };
+
+        pc.onconnectionstatechange += state =>
+        {
+            LogIceStateChanged(_logger, fileRequestId, state.ToString());
+            if (state == RTCPeerConnectionState.failed || state == RTCPeerConnectionState.disconnected)
+                _ = TriggerRelayReceiveAsync(fileRequestId, connection, config, cts.Token);
+        };
+
+        // Wait for offer to arrive via HandleIceSignalAsync
+        LogWaitingForOffer(_logger, fileRequestId);
+        string sdpOffer;
+        try
+        {
+            sdpOffer = await offerTcs.Task.WaitAsync(cts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            LogIceTimeout(_logger, fileRequestId);
+            CleanupSession(fileRequestId);
+            return;
+        }
+
+        var remoteOffer = new RTCSessionDescriptionInit
+        {
+            type = RTCSdpType.offer,
+            sdp = sdpOffer
+        };
+        pc.setRemoteDescription(remoteOffer);
+
+        var answer = pc.createAnswer();
+        await pc.setLocalDescription(answer).ConfigureAwait(false);
+        LogSdpAnswerCreated(_logger, fileRequestId);
+
+        await connection.SendAsync("ForwardIceSignal",
+            new IceSignal(fileRequestId, IceSignalType.Answer, answer.sdp),
+            cts.Token).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///     Routes an incoming IceSignal to the correct peer connection.
+    ///     Called by the SignalR message handler when the server forwards an IceSignal.
+    /// </summary>
+    public void HandleIceSignal(IceSignal signal)
+    {
+        if (!_sessions.TryGetValue(signal.FileRequestId, out var session))
+        {
+            LogIceSignalNoSession(_logger, signal.FileRequestId, signal.Type.ToString());
+            return;
+        }
+
+        switch (signal.Type)
+        {
+            case IceSignalType.Offer:
+                // Answerer: unblock BeginAsAnswererAsync to proceed with answer
+                session.OfferTcs?.TrySetResult(signal.Payload);
+                break;
+
+            case IceSignalType.Answer:
+                // Offerer: apply remote description
+                session.PeerConnection.setRemoteDescription(new RTCSessionDescriptionInit
+                {
+                    type = RTCSdpType.answer,
+                    sdp = signal.Payload
+                });
+                LogSdpAnswerApplied(_logger, signal.FileRequestId);
+                break;
+
+            case IceSignalType.Candidate:
+                try
+                {
+                    var init = JsonSerializer.Deserialize<IceCandidateInit>(signal.Payload);
+                    if (init is not null)
+                        session.PeerConnection.addIceCandidate(new RTCIceCandidateInit
+                        {
+                            candidate = init.Candidate,
+                            sdpMid = init.SdpMid,
+                            sdpMLineIndex = (ushort)(init.SdpMLineIndex ?? 0)
+                        });
+                }
+                catch (Exception ex)
+                {
+                    LogIceCandidateAddFailed(_logger, ex, signal.FileRequestId);
+                }
+                break;
+        }
+    }
+
+    /// <summary>
+    ///     Cancels and cleans up an in-progress ICE session.
+    /// </summary>
+    public void Cancel(Guid fileRequestId)
+    {
+        CleanupSession(fileRequestId);
+        _fileTransfer.Cancel(fileRequestId);
+    }
+
+    /// <summary>
+    ///     Starts a streaming (non-saving) transfer as answerer: same ICE flow as US1 but instead of
+    ///     writing to disk the DataChannel bytes are piped into <see cref="LocalStreamEndpoint"/>.
+    /// </summary>
+    /// <returns>The localhost URL Jellyfin can play, or null if ICE negotiation fails.</returns>
+    public async Task<string?> StartStreamingTransferAsync(
+        Guid fileRequestId, HubConnection connection, CancellationToken ct = default)
+    {
+        var config = _configProvider.GetConfiguration();
+        var pc = CreatePeerConnection(config);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        cts.CancelAfter(IceTimeoutMs);
+
+        var offerTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var streamUrlTcs = new TaskCompletionSource<string?>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var session = new IceNegotiationSession(fileRequestId, pc, IceRole.Answerer, cts)
+        {
+            OfferTcs = offerTcs
+        };
+        _sessions[fileRequestId] = session;
+
+        pc.onicecandidate += candidate =>
+        {
+            if (candidate is null) return;
+            var payload = JsonSerializer.Serialize(new
+            {
+                candidate = candidate.candidate,
+                sdpMid = candidate.sdpMid,
+                sdpMLineIndex = candidate.sdpMLineIndex
+            });
+            _ = ForwardCandidateAsync(connection, fileRequestId, payload, cts.Token);
+        };
+
+        pc.ondatachannel += dc =>
+        {
+            session.DataChannel = dc;
+            dc.onopen += () =>
+            {
+                LogDataChannelOpen(_logger, fileRequestId, IceRole.Answerer);
+                session.State = IceSessionState.Connected;
+                var pipeReader = _fileTransfer.ReceiveStreamingAsync(fileRequestId, dc, cts.Token);
+                _ = Task.Run(async () =>
+                {
+                    var token = Guid.NewGuid();
+                    var url = await _streamEndpoint.RegisterStreamAsync(token, pipeReader, cts.Token)
+                        .ConfigureAwait(false);
+                    streamUrlTcs.TrySetResult(url);
+                });
+            };
+            dc.onclose += () =>
+            {
+                LogDataChannelClosed(_logger, fileRequestId);
+                streamUrlTcs.TrySetResult(null);
+            };
+        };
+
+        pc.onconnectionstatechange += state =>
+        {
+            if (state == RTCPeerConnectionState.failed || state == RTCPeerConnectionState.disconnected)
+                streamUrlTcs.TrySetResult(null);
+        };
+
+        string sdpOffer;
+        try
+        {
+            sdpOffer = await offerTcs.Task.WaitAsync(cts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            LogIceTimeout(_logger, fileRequestId);
+            CleanupSession(fileRequestId);
+            return null;
+        }
+
+        pc.setRemoteDescription(new RTCSessionDescriptionInit { type = RTCSdpType.offer, sdp = sdpOffer });
+        var answer = pc.createAnswer();
+        await pc.setLocalDescription(answer).ConfigureAwait(false);
+
+        await connection.SendAsync("ForwardIceSignal",
+            new IceSignal(fileRequestId, IceSignalType.Answer, answer.sdp),
+            cts.Token).ConfigureAwait(false);
+
+        return await streamUrlTcs.Task.WaitAsync(cts.Token).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///     Returns the active streaming URL for the given file request, or null if not streaming.
+    /// </summary>
+    public string? GetStreamUrl(Guid fileRequestId)
+    {
+        // Stream URLs are tracked inside LocalStreamEndpoint by token, not by fileRequestId.
+        // This method is a hook for the plugin UI layer — full wiring is deferred to the UI integration task.
+        return null;
+    }
+
+    /// <summary>
+    ///     Delivers a relay chunk to the waiting ReceiveRelayAsync loop.
+    ///     Called from the SignalR RelayReceiveChunk handler.
+    /// </summary>
+    public void EnqueueRelayChunk(RelayChunk chunk) => _fileTransfer.EnqueueRelayChunk(chunk);
+
+    /// <summary>
+    ///     Switches this peer to relay receive mode when the sender notifies us via RelayTransferStart.
+    ///     Called from the SignalR RelayTransferStart handler.
+    /// </summary>
+    public async Task StartRelayReceiveModeAsync(RelayTransferStart message, HubConnection connection)
+    {
+        var config = _configProvider.GetConfiguration();
+        await TriggerRelayReceiveAsync(message.FileRequestId, connection, config, CancellationToken.None)
+            .ConfigureAwait(false);
+    }
+
+    private RTCPeerConnection CreatePeerConnection(PluginConfiguration config)
+    {
+        var stunServer = string.IsNullOrWhiteSpace(config.StunServer)
+            ? "stun.l.google.com:19302"
+            : config.StunServer;
+
+        var configuration = new RTCConfiguration
+        {
+            iceServers =
+            [
+                new RTCIceServer { urls = $"stun:{stunServer}" }
+            ]
+        };
+
+        var pc = new RTCPeerConnection(configuration);
+        return pc;
+    }
+
+    private async Task ForwardCandidateAsync(
+        HubConnection connection, Guid fileRequestId, string candidateJson, CancellationToken ct)
+    {
+        try
+        {
+            await connection.SendAsync("ForwardIceSignal",
+                new IceSignal(fileRequestId, IceSignalType.Candidate, candidateJson),
+                ct).ConfigureAwait(false);
+            LogCandidateForwarded(_logger, fileRequestId);
+        }
+        catch (Exception ex)
+        {
+            LogCandidateForwardFailed(_logger, ex, fileRequestId);
+        }
+    }
+
+    private async Task TriggerRelayFallbackAsync(
+        Guid fileRequestId, string jellyfinItemId, HubConnection connection,
+        PluginConfiguration config, CancellationToken ct)
+    {
+        if (!_sessions.TryGetValue(fileRequestId, out var session) || session.State == IceSessionState.Relay)
+            return;
+
+        session.State = IceSessionState.Relay;
+        LogRelayFallbackEngaged(_logger, fileRequestId);
+
+        using var activity = FederationTelemetry.PluginActivitySource.StartActivity(
+            "ice.relay.fallback", ActivityKind.Client);
+        FederationMetrics.RecordOperation(
+            $"file.transfer.mode.{TransferTransportMode.Relay.ToString().ToLowerInvariant()}",
+            "plugin", "selected", TimeSpan.Zero, FederationPlugin.ReleaseVersion);
+
+        // Notify receiver to switch to relay receive mode
+        try
+        {
+            await connection.SendAsync("ForwardRelayTransferStart",
+                new RelayTransferStart(fileRequestId, IceRole.Offerer), ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            LogRelayNotifyFailed(_logger, ex, fileRequestId);
+        }
+
+        await _fileTransfer.SendRelayAsync(fileRequestId, jellyfinItemId, connection, config, ct)
+            .ConfigureAwait(false);
+    }
+
+    private async Task TriggerRelayReceiveAsync(
+        Guid fileRequestId, HubConnection connection, PluginConfiguration config, CancellationToken ct)
+    {
+        if (!_sessions.TryGetValue(fileRequestId, out var session) || session.State == IceSessionState.Relay)
+            return;
+
+        session.State = IceSessionState.Relay;
+        LogRelayReceiveModeEngaged(_logger, fileRequestId);
+        await _fileTransfer.ReceiveRelayAsync(fileRequestId, connection, config, ct).ConfigureAwait(false);
+    }
+
+    private void CleanupSession(Guid fileRequestId)
+    {
+        if (_sessions.TryRemove(fileRequestId, out var session))
+        {
+            try { session.Cts.Cancel(); } catch { /* already cancelled */ }
+            try { session.PeerConnection.Close("cleanup"); } catch { /* already closed */ }
+            LogSessionCleaned(_logger, fileRequestId);
+        }
+    }
+
+    private record IceCandidateInit
+    {
+        public string? Candidate { get; init; }
+        public string? SdpMid { get; init; }
+        public ushort? SdpMLineIndex { get; init; }
+    }
+}
+
+/// <summary>
+///     Holds per-FileRequest ICE negotiation state.
+/// </summary>
+internal sealed class IceNegotiationSession
+{
+    public IceNegotiationSession(Guid fileRequestId, RTCPeerConnection peerConnection,
+        IceRole role, CancellationTokenSource cts)
+    {
+        FileRequestId = fileRequestId;
+        PeerConnection = peerConnection;
+        Role = role;
+        Cts = cts;
+        CreatedAt = DateTimeOffset.UtcNow;
+        State = IceSessionState.Gathering;
+    }
+
+    public Guid FileRequestId { get; }
+    public RTCPeerConnection PeerConnection { get; }
+    public RTCDataChannel? DataChannel { get; set; }
+    public IceRole Role { get; }
+    public IceSessionState State { get; set; }
+    public DateTimeOffset CreatedAt { get; }
+    public CancellationTokenSource Cts { get; }
+
+    /// <summary>Set by answerer to unblock answer creation once offer arrives.</summary>
+    public TaskCompletionSource<string>? OfferTcs { get; init; }
+}

--- a/src/JellyFederation.Plugin/Web/configurationpage.html
+++ b/src/JellyFederation.Plugin/Web/configurationpage.html
@@ -89,26 +89,41 @@
                 </div>
 
                 <div class="inputContainer">
+                    <label class="inputLabel inputLabelUnfocused" for="stunServer">
+                        STUN Server
+                    </label>
+                    <input id="stunServer" is="emby-input"
+                           name="StunServer" placeholder="stun.l.google.com:19302"
+                           type="text"/>
+                    <div class="fieldDescription">
+                        STUN server used for WebRTC ICE candidate gathering. Leave empty to use the default
+                        (stun.l.google.com:19302). Override for air-gapped or self-hosted deployments.
+                    </div>
+                </div>
+
+                <div class="inputContainer">
                     <label class="inputLabel inputLabelUnfocused" for="overridePublicIp">
-                        Override Public IP (optional)
+                        Override Public IP <span style="font-weight:normal;opacity:0.7">(optional — only needed for old plugin versions)</span>
                     </label>
                     <input id="overridePublicIp" is="emby-input"
                            name="OverridePublicIp" placeholder="203.0.113.25"
                            type="text"/>
                     <div class="fieldDescription">
-                        Leave empty to auto-detect. Set this when running behind NAT/Docker with a known public IP.
+                        Leave empty. Only needed when communicating with peers running older plugin versions
+                        that use UDP hole-punching instead of WebRTC ICE.
                     </div>
                 </div>
 
                 <div class="inputContainer">
                     <label class="inputLabel inputLabelUnfocused" for="holePunchPort">
-                        Hole Punch UDP Port
+                        Hole Punch UDP Port <span style="font-weight:normal;opacity:0.7">(optional — only needed for old plugin versions)</span>
                     </label>
                     <input id="holePunchPort" is="emby-input"
                            min="0" name="HolePunchPort" placeholder="0"
                            type="number"/>
                     <div class="fieldDescription">
-                        0 = ephemeral port. Use a fixed port when you need NAT port-forwarding.
+                        0 = ephemeral port. Only needed when talking to peers on older plugin versions that
+                        use UDP hole-punching. WebRTC ICE peers do not require a fixed port.
                     </div>
                 </div>
 
@@ -157,6 +172,7 @@
                 document.querySelector('#serverName').value = config.ServerName || '';
                 document.querySelector('#publicJellyfinUrl').value = config.PublicJellyfinUrl || '';
                 document.querySelector('#downloadDirectory').value = config.DownloadDirectory || '';
+                document.querySelector('#stunServer').value = config.StunServer || '';
                 document.querySelector('#overridePublicIp').value = config.OverridePublicIp || '';
                 document.querySelector('#holePunchPort').value = config.HolePunchPort || 0;
                 document.querySelector('#preferQuicForLargeFiles').checked = config.PreferQuicForLargeFiles !== false;
@@ -182,6 +198,7 @@
                 config.ServerName = form.querySelector('#serverName').value.trim();
                 config.PublicJellyfinUrl = form.querySelector('#publicJellyfinUrl').value.trim();
                 config.DownloadDirectory = form.querySelector('#downloadDirectory').value.trim();
+                config.StunServer = form.querySelector('#stunServer').value.trim();
                 config.OverridePublicIp = form.querySelector('#overridePublicIp').value.trim();
 
                 var parsedPort = parseInt(form.querySelector('#holePunchPort').value, 10);

--- a/src/JellyFederation.Server/Hubs/FederationHub.Logging.cs
+++ b/src/JellyFederation.Server/Hubs/FederationHub.Logging.cs
@@ -118,4 +118,45 @@ public partial class FederationHub
         string code,
         string category,
         string message);
+
+    [LoggerMessage(27, LogLevel.Information, "ICE negotiation started for request {RequestId}")]
+    private static partial void LogIceNegotiationStarted(ILogger logger, Guid requestId);
+
+    [LoggerMessage(28, LogLevel.Warning,
+        "ForwardIceSignal: unknown connection {ConnectionId} for request {RequestId}")]
+    private static partial void LogForwardIceSignalUnknownConnection(ILogger logger, string connectionId,
+        Guid requestId);
+
+    [LoggerMessage(29, LogLevel.Warning, "ForwardIceSignal: file request {RequestId} not found — dropping")]
+    private static partial void LogForwardIceSignalNotFound(ILogger logger, Guid requestId);
+
+    [LoggerMessage(30, LogLevel.Warning,
+        "ForwardIceSignal: peer {TargetServerId} offline for request {RequestId} — dropping")]
+    private static partial void LogForwardIceSignalPeerOffline(ILogger logger, Guid requestId, Guid targetServerId);
+
+    [LoggerMessage(31, LogLevel.Debug,
+        "Forwarded ICE signal for request {RequestId}: type={Type} from {SenderId} to {TargetId}")]
+    private static partial void LogForwardedIceSignal(ILogger logger, Guid requestId, string type, Guid senderId,
+        Guid targetId);
+
+    [LoggerMessage(32, LogLevel.Warning,
+        "RelaySendChunk: unknown connection {ConnectionId} for request {RequestId}")]
+    private static partial void LogRelaySendChunkUnknownConnection(ILogger logger, string connectionId,
+        Guid requestId);
+
+    [LoggerMessage(33, LogLevel.Warning, "RelaySendChunk: file request {RequestId} not found — dropping")]
+    private static partial void LogRelaySendChunkNotFound(ILogger logger, Guid requestId);
+
+    [LoggerMessage(34, LogLevel.Warning,
+        "RelaySendChunk: receiver {ReceiverServerId} offline for request {RequestId} — dropping")]
+    private static partial void LogRelaySendChunkReceiverOffline(ILogger logger, Guid requestId,
+        Guid receiverServerId);
+
+    [LoggerMessage(35, LogLevel.Debug,
+        "Relay chunk forwarded for request {RequestId}: index={ChunkIndex}, isEof={IsEof}")]
+    private static partial void LogRelayChunkForwarded(ILogger logger, Guid requestId, long chunkIndex, bool isEof);
+
+    [LoggerMessage(36, LogLevel.Debug,
+        "RelayTransferStart forwarded for request {RequestId} to server {TargetServerId}")]
+    private static partial void LogRelayTransferStartForwarded(ILogger logger, Guid requestId, Guid targetServerId);
 }

--- a/src/JellyFederation.Server/Hubs/FederationHub.cs
+++ b/src/JellyFederation.Server/Hubs/FederationHub.cs
@@ -221,7 +221,8 @@ public partial class FederationHub : Hub
                     message.UdpPort,
                     message.SupportsQuic,
                     message.LargeFileThresholdBytes,
-                    out var candidates))
+                    out var candidates,
+                    message.SupportsIce))
                 await DispatchHolePunch(request, candidates).ConfigureAwait(false);
 
             FederationTelemetry.SetOutcome(activity, FederationTelemetry.OutcomeSuccess);
@@ -319,6 +320,28 @@ public partial class FederationHub : Hub
             return;
         }
 
+        // If both peers support WebRTC ICE, bypass hole-punch and start ICE negotiation instead.
+        if (sender.SupportsIce && receiver.SupportsIce)
+        {
+            request.SelectedTransportMode = TransferTransportMode.WebRtc;
+            request.TransportSelectionReason = TransferSelectionReason.IceNegotiated;
+            request.Status = FileRequestStatus.HolePunching;
+            await _db.SaveChangesAsync().ConfigureAwait(false);
+
+            await Clients.Client(sender.ConnectionId).SendAsync(
+                "IceNegotiateStart",
+                new IceNegotiateStart(request.Id, IceRole.Offerer)).ConfigureAwait(false);
+
+            await Clients.Client(receiver.ConnectionId).SendAsync(
+                "IceNegotiateStart",
+                new IceNegotiateStart(request.Id, IceRole.Answerer)).ConfigureAwait(false);
+
+            LogIceNegotiationStarted(_logger, request.Id);
+            LogTransportModeSelected(_logger, request.Id, TransferTransportMode.WebRtc, TransferSelectionReason.IceNegotiated);
+            FederationMetrics.RecordOperation("file.transfer.mode.webrtc", "server", "selected", TimeSpan.Zero);
+            return;
+        }
+
         var senderIp = _tracker.GetPublicIp(sender.ConnectionId);
         var receiverIp = _tracker.GetPublicIp(receiver.ConnectionId);
 
@@ -364,6 +387,96 @@ public partial class FederationHub : Hub
             "server",
             "selected",
             TimeSpan.Zero);
+    }
+
+    /// <summary>
+    ///     Forwards an ICE signal (offer, answer, or trickle candidate) from one peer to the other.
+    ///     The server treats the payload as opaque — it only routes by FileRequestId.
+    /// </summary>
+    public async Task ForwardIceSignal(IceSignal signal)
+    {
+        var senderId = _tracker.GetServerId(Context.ConnectionId);
+        if (senderId is null)
+        {
+            LogForwardIceSignalUnknownConnection(_logger, Context.ConnectionId, signal.FileRequestId);
+            return;
+        }
+
+        var request = await _db.FileRequests.FindAsync(signal.FileRequestId).ConfigureAwait(false);
+        if (request is null)
+        {
+            LogForwardIceSignalNotFound(_logger, signal.FileRequestId);
+            return;
+        }
+
+        // Determine the other peer's server ID
+        var targetServerId = senderId.Value == request.OwningServerId
+            ? request.RequestingServerId
+            : request.OwningServerId;
+
+        var targetConnectionId = _tracker.GetConnectionId(targetServerId);
+        if (targetConnectionId is null)
+        {
+            LogForwardIceSignalPeerOffline(_logger, signal.FileRequestId, targetServerId);
+            return;
+        }
+
+        await Clients.Client(targetConnectionId).SendAsync("IceSignal", signal).ConfigureAwait(false);
+        LogForwardedIceSignal(_logger, signal.FileRequestId, signal.Type.ToString(), senderId.Value, targetServerId);
+    }
+
+    /// <summary>
+    ///     Receives a relay chunk from the sender plugin and forwards it to the receiver plugin.
+    ///     Used when direct ICE negotiation fails. The server never buffers more than one chunk.
+    /// </summary>
+    public async Task RelaySendChunk(RelayChunk chunk)
+    {
+        var senderId = _tracker.GetServerId(Context.ConnectionId);
+        if (senderId is null)
+        {
+            LogRelaySendChunkUnknownConnection(_logger, Context.ConnectionId, chunk.FileRequestId);
+            return;
+        }
+
+        var request = await _db.FileRequests.FindAsync(chunk.FileRequestId).ConfigureAwait(false);
+        if (request is null)
+        {
+            LogRelaySendChunkNotFound(_logger, chunk.FileRequestId);
+            return;
+        }
+
+        var receiverServerId = request.RequestingServerId;
+        var receiverConnectionId = _tracker.GetConnectionId(receiverServerId);
+        if (receiverConnectionId is null)
+        {
+            LogRelaySendChunkReceiverOffline(_logger, chunk.FileRequestId, receiverServerId);
+            return;
+        }
+
+        await Clients.Client(receiverConnectionId).SendAsync("RelayReceiveChunk", chunk).ConfigureAwait(false);
+        LogRelayChunkForwarded(_logger, chunk.FileRequestId, chunk.ChunkIndex, chunk.IsEof);
+    }
+
+    /// <summary>
+    ///     Notifies the receiver plugin that relay mode has been engaged by the sender.
+    /// </summary>
+    public async Task ForwardRelayTransferStart(RelayTransferStart message)
+    {
+        var senderId = _tracker.GetServerId(Context.ConnectionId);
+        if (senderId is null) return;
+
+        var request = await _db.FileRequests.FindAsync(message.FileRequestId).ConfigureAwait(false);
+        if (request is null) return;
+
+        var targetServerId = senderId.Value == request.OwningServerId
+            ? request.RequestingServerId
+            : request.OwningServerId;
+
+        var targetConnectionId = _tracker.GetConnectionId(targetServerId);
+        if (targetConnectionId is null) return;
+
+        await Clients.Client(targetConnectionId).SendAsync("RelayTransferStart", message).ConfigureAwait(false);
+        LogRelayTransferStartForwarded(_logger, message.FileRequestId, targetServerId);
     }
 
     private async Task<TransferSelection> SelectTransportModeAsync(

--- a/src/JellyFederation.Server/Services/ServerConnectionTracker.cs
+++ b/src/JellyFederation.Server/Services/ServerConnectionTracker.cs
@@ -22,6 +22,10 @@ public partial class ServerConnectionTracker
     // fileRequestId -> (connectionId, udpPort) for hole punch staging
     private readonly ConcurrentDictionary<Guid, HolePunchCandidate[]> _holePunchStaging = new();
 
+    // fileRequestId -> (senderConnectionId?, receiverConnectionId?) for ICE capability tracking
+    // Populated as each peer calls ReportHolePunchReady with SupportsIce=true.
+    private readonly ConcurrentDictionary<Guid, IceCandidacy[]> _iceCandidacies = new();
+
     private readonly ILogger<ServerConnectionTracker> _logger;
 
     // serverId -> connectionId
@@ -94,6 +98,37 @@ public partial class ServerConnectionTracker
     }
 
     /// <summary>
+    ///     Records that a peer supports ICE for the given file request.
+    ///     Returns true if BOTH peers have now declared SupportsIce=true,
+    ///     and outputs the connection IDs for sender and receiver.
+    /// </summary>
+    public bool TryAddIceCandidacy(
+        Guid fileRequestId,
+        Guid serverId,
+        string connectionId,
+        out IceCandidacy[] candidates)
+    {
+        var entry = new IceCandidacy(serverId, connectionId);
+
+        candidates = _iceCandidacies.AddOrUpdate(
+            fileRequestId,
+            _ => [entry],
+            (_, existing) =>
+            {
+                var others = existing.Where(c => c.ServerId != serverId).ToArray();
+                return [.. others, entry];
+            });
+
+        if (candidates.Select(c => c.ServerId).Distinct().Count() >= 2)
+        {
+            _iceCandidacies.TryRemove(fileRequestId, out _);
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
     ///     Records that a peer is ready for hole punching on the given file request.
     ///     Returns true if BOTH peers are now ready (triggers punch).
     /// </summary>
@@ -104,10 +139,11 @@ public partial class ServerConnectionTracker
         int udpPort,
         bool supportsQuic,
         long largeFileThresholdBytes,
-        out HolePunchCandidate[] candidates)
+        out HolePunchCandidate[] candidates,
+        bool supportsIce = false)
     {
         var threshold = largeFileThresholdBytes > 0 ? largeFileThresholdBytes : long.MaxValue;
-        var entry = new HolePunchCandidate(serverId, connectionId, udpPort, supportsQuic, threshold);
+        var entry = new HolePunchCandidate(serverId, connectionId, udpPort, supportsQuic, threshold, supportsIce);
 
         candidates = _holePunchStaging.AddOrUpdate(
             fileRequestId,
@@ -138,13 +174,15 @@ public record HolePunchCandidate
         string ConnectionId,
         int UdpPort,
         bool SupportsQuic,
-        long LargeFileThresholdBytes)
+        long LargeFileThresholdBytes,
+        bool SupportsIce = false)
     {
         this.ServerId = ServerId;
         this.ConnectionId = ConnectionId;
         this.UdpPort = UdpPort;
         this.SupportsQuic = SupportsQuic;
         this.LargeFileThresholdBytes = LargeFileThresholdBytes;
+        this.SupportsIce = SupportsIce;
     }
 
     public Guid ServerId { get; init; }
@@ -152,17 +190,21 @@ public record HolePunchCandidate
     public int UdpPort { get; init; }
     public bool SupportsQuic { get; init; }
     public long LargeFileThresholdBytes { get; init; }
+    public bool SupportsIce { get; init; }
 
     public void Deconstruct(out Guid ServerId, out string ConnectionId, out int UdpPort, out bool SupportsQuic,
-        out long LargeFileThresholdBytes)
+        out long LargeFileThresholdBytes, out bool SupportsIce)
     {
         ServerId = this.ServerId;
         ConnectionId = this.ConnectionId;
         UdpPort = this.UdpPort;
         SupportsQuic = this.SupportsQuic;
         LargeFileThresholdBytes = this.LargeFileThresholdBytes;
+        SupportsIce = this.SupportsIce;
     }
 }
+
+public record IceCandidacy(Guid ServerId, string ConnectionId);
 
 public readonly record struct TransferSelection
 {

--- a/src/JellyFederation.Shared/Models/TransferTransport.cs
+++ b/src/JellyFederation.Shared/Models/TransferTransport.cs
@@ -3,7 +3,9 @@ namespace JellyFederation.Shared.Models;
 public enum TransferTransportMode
 {
     ArqUdp = 0,
-    Quic = 1
+    Quic = 1,
+    WebRtc = 2,
+    Relay = 3
 }
 
 public enum TransferSelectionReason
@@ -13,7 +15,19 @@ public enum TransferSelectionReason
     QuicUnsupportedPeer = 2,
     QuicUnavailableLocal = 3,
     NegotiationFailed = 4,
-    FallbackAfterError = 5
+    FallbackAfterError = 5,
+    IceNegotiated = 10,
+    IceFailed = 11,
+    PeerLacksIce = 12
+}
+
+public enum IceSessionState
+{
+    Gathering,
+    Connecting,
+    Connected,
+    Failed,
+    Relay
 }
 
 public enum TransferFailureCategory

--- a/src/JellyFederation.Shared/SignalR/FederationMessages.cs
+++ b/src/JellyFederation.Shared/SignalR/FederationMessages.cs
@@ -73,13 +73,15 @@ public record HolePunchReady
         int UdpPort, // The port this plugin bound locally
         string? OverridePublicIp = null, // Optional: override the IP the server uses for this peer
         bool SupportsQuic = false,
-        long LargeFileThresholdBytes = 0)
+        long LargeFileThresholdBytes = 0,
+        bool SupportsIce = false) // NEW: signals WebRTC DataChannel capability
     {
         this.FileRequestId = FileRequestId;
         this.UdpPort = UdpPort;
         this.OverridePublicIp = OverridePublicIp;
         this.SupportsQuic = SupportsQuic;
         this.LargeFileThresholdBytes = LargeFileThresholdBytes;
+        this.SupportsIce = SupportsIce;
     }
 
     public Guid FileRequestId { get; init; }
@@ -88,17 +90,66 @@ public record HolePunchReady
     public bool SupportsQuic { get; init; }
     public long LargeFileThresholdBytes { get; init; }
 
+    /// <summary>
+    ///     When true the plugin supports WebRTC DataChannel (ICE) transfer.
+    ///     Old plugin versions omit this field; the server treats absent as false.
+    /// </summary>
+    public bool SupportsIce { get; init; } = false;
+
     public void Deconstruct(out Guid FileRequestId, out int UdpPort, // The port this plugin bound locally
         out string? OverridePublicIp, // Optional: override the IP the server uses for this peer
-        out bool SupportsQuic, out long LargeFileThresholdBytes)
+        out bool SupportsQuic, out long LargeFileThresholdBytes, out bool SupportsIce)
     {
         FileRequestId = this.FileRequestId;
         UdpPort = this.UdpPort;
         OverridePublicIp = this.OverridePublicIp;
         SupportsQuic = this.SupportsQuic;
         LargeFileThresholdBytes = this.LargeFileThresholdBytes;
+        SupportsIce = this.SupportsIce;
     }
 }
+
+/// <summary>
+///     WebRTC ICE signal type forwarded between peers via the federation server.
+/// </summary>
+public enum IceSignalType
+{
+    Offer,
+    Answer,
+    Candidate
+}
+
+/// <summary>
+///     Role assigned to each peer when ICE negotiation begins.
+/// </summary>
+public enum IceRole
+{
+    Offerer,  // Sender — creates the SDP offer
+    Answerer  // Receiver — creates the SDP answer
+}
+
+/// <summary>
+///     Forwarded between plugins via the federation server to exchange SDP offers,
+///     answers, and trickle ICE candidates.
+/// </summary>
+public record IceSignal(Guid FileRequestId, IceSignalType Type, string Payload);
+
+/// <summary>
+///     Sent by the federation server to each peer once both have advertised
+///     SupportsIce=true. Triggers WebRTC DataChannel negotiation.
+/// </summary>
+public record IceNegotiateStart(Guid FileRequestId, IceRole Role);
+
+/// <summary>
+///     Relay fallback chunk: sent plugin→server→plugin when direct ICE fails.
+///     Max payload 32 KB. IsEof=true signals end of transfer.
+/// </summary>
+public record RelayChunk(Guid FileRequestId, long ChunkIndex, bool IsEof, byte[] Data);
+
+/// <summary>
+///     Notifies the receiver plugin that relay mode has been engaged.
+/// </summary>
+public record RelayTransferStart(Guid FileRequestId, IceRole Role);
 
 /// <summary>
 ///     Sent by a plugin to the federation server to report hole punch outcome.


### PR DESCRIPTION
Implement WebRTC DataChannel negotiation and file transfer with
 automatic SignalR relay fallback. Add shared signaling models,
 server-side routing/session tracking, plugin transport orchestration,
 streaming endpoint support, and related config/UI/logging updates.