### PR TITLE
ci: install pinned dotnet sdk

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: "9.0.x"
+          global-json-file: global.json
 
       - name: Build
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: "9.0.x"
+          global-json-file: global.json
 
       - name: Get version from tag
         id: version

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,3 +14,7 @@ on:
 jobs:
   call:
     uses: jellyfin/jellyfin-meta-plugins/.github/workflows/test.yaml@master
+    with:
+      dotnet-version: |
+        9.0.x
+        10.0.x


### PR DESCRIPTION
## Summary\n- install the .NET SDK requested by global.json in plugin build and publish workflows\n- pass both .NET 9 and .NET 10 to the reusable Jellyfin test workflow\n\n## Why\nPR builds can fail after Renovate updates global.json because the workflow only installs .NET 9 before invoking dotnet. Installing the SDK from global.json keeps CI aligned with the repository SDK pin.\n\n## Testing\n- validated edited workflow YAML parses locally