### PR TITLE
ci: set Renovate git author

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -112,5 +112,6 @@
         "before 5am on the first day of the month"
       ]
     }
-  ]
+  ],
+  "gitAuthor": "Renovate Bot <20138976+lukasschachner@users.noreply.github.com>"
 }


### PR DESCRIPTION
## Summary\n- configure Renovate to author commits as a repo-owned noreply identity\n- avoid the default renovate@whitesourcesoftware.com author that GitHub flags because it belongs to Mend\n\n## Notes\nExisting Renovate commits keep their old author. New Renovate branches will use this identity after the PR is merged.