### PR TITLE
chore: add postgres devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,5 @@
+FROM mcr.microsoft.com/devcontainers/dotnet:1-10.0-bookworm
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends postgresql-client \
+    && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,63 @@
+{
+  "name": "JellyFederation",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "devcontainer",
+  "workspaceFolder": "/workspaces/jellyfederation",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "24"
+    },
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-dotnettools.csharp",
+        "ms-dotnettools.csdevkit",
+        "ms-azuretools.vscode-docker",
+        "EditorConfig.EditorConfig",
+        "GitHub.vscode-github-actions"
+      ]
+    }
+  },
+  "forwardPorts": [
+    5264,
+    5173,
+    5432,
+    8080,
+    3000,
+    4317,
+    4318
+  ],
+  "portsAttributes": {
+    "5264": {
+      "label": "JellyFederation Server"
+    },
+    "5173": {
+      "label": "JellyFederation Web (Vite)"
+    },
+    "5432": {
+      "label": "PostgreSQL"
+    },
+    "8080": {
+      "label": "Adminer"
+    },
+    "3000": {
+      "label": "Grafana LGTM"
+    },
+    "4317": {
+      "label": "OTLP gRPC"
+    },
+    "4318": {
+      "label": "OTLP HTTP"
+    }
+  },
+  "containerEnv": {
+    "Database__Provider": "PostgreSQL",
+    "ConnectionStrings__Default": "Host=postgres;Port=5432;Database=jellyfederation;Username=jellyfederation;Password=jellyfederation",
+    "Telemetry__OtlpEndpoint": "http://lgtm:4317"
+  },
+  "postCreateCommand": "dotnet restore JellyFederation.slnx && dotnet tool restore && cd src/JellyFederation.Web && npm ci",
+  "postStartCommand": "./scripts/devcontainer-post-start.sh",
+  "postAttachCommand": "printf '\\nPostgreSQL is available at Host=postgres;Database=jellyfederation;Username=jellyfederation;Password=jellyfederation inside the devcontainer, and localhost:5432 from the host.\\nRun: dotnet run --project src/JellyFederation.Server/JellyFederation.Server.csproj\\n'"
+}

--- a/.devcontainer/docker-compose.full.yml
+++ b/.devcontainer/docker-compose.full.yml
@@ -1,0 +1,47 @@
+services:
+  jellyfederation-server:
+    profiles: ["full-stack"]
+    build:
+      context: ..
+      dockerfile: src/JellyFederation.Server/Dockerfile
+    environment:
+      Database__Provider: PostgreSQL
+      ConnectionStrings__Default: Host=postgres;Port=5432;Database=jellyfederation;Username=jellyfederation;Password=jellyfederation
+      Telemetry__OtlpEndpoint: http://lgtm:4317
+      Urls: http://0.0.0.0:5264
+    ports:
+      - "5264:5264"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      lgtm:
+        condition: service_started
+
+  jellyfederation-web:
+    profiles: ["full-stack"]
+    image: node:24.15.0-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
+    working_dir: /workspace/src/JellyFederation.Web
+    volumes:
+      - ..:/workspace:cached
+    command: sh -lc "npm ci && npm run dev -- --host 0.0.0.0"
+    ports:
+      - "5173:5173"
+    depends_on:
+      jellyfederation-server:
+        condition: service_started
+
+  jellyfin:
+    profiles: ["full-stack"]
+    image: jellyfin/jellyfin:10.11.0
+    restart: unless-stopped
+    ports:
+      - "8096:8096"
+    volumes:
+      - jellyfin-config:/config
+      - jellyfin-cache:/cache
+      - jellyfin-media:/media
+
+volumes:
+  jellyfin-config:
+  jellyfin-cache:
+  jellyfin-media:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,55 @@
+services:
+  devcontainer:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ..:/workspaces/jellyfederation:cached
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: sleep infinity
+    environment:
+      Database__Provider: PostgreSQL
+      ConnectionStrings__Default: Host=postgres;Port=5432;Database=jellyfederation;Username=jellyfederation;Password=jellyfederation
+      Telemetry__OtlpEndpoint: http://lgtm:4317
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  postgres:
+    image: postgres:17-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: jellyfederation
+      POSTGRES_USER: jellyfederation
+      POSTGRES_PASSWORD: jellyfederation
+    ports:
+      - "5432:5432"
+    volumes:
+      - jellyfederation-postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U jellyfederation -d jellyfederation"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  adminer:
+    profiles: ["db-tools", "full-stack"]
+    image: adminer:5-standalone
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  lgtm:
+    profiles: ["observability", "full-stack"]
+    image: grafana/otel-lgtm:latest@sha256:764b657d5c750a151fbe2f9acd8cd8edeec873b8f5e3179380d7d08b69797c2e
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+      - "4317:4317"
+      - "4318:4318"
+
+volumes:
+  jellyfederation-postgres-data:

--- a/README.md
+++ b/README.md
@@ -22,6 +22,53 @@ testable increments.
 
 ## Local development
 
+### Devcontainer
+
+This repository includes a VS Code/devcontainer setup with .NET 10, Node.js 24,
+Docker CLI access, the PostgreSQL client, and PostgreSQL 17. Optional compose
+profiles add Adminer and the LGTM observability stack. The container waits for
+PostgreSQL and applies PostgreSQL EF Core migrations on start. Inside the container
+the server defaults to PostgreSQL via:
+
+```text
+Database__Provider=PostgreSQL
+ConnectionStrings__Default=Host=postgres;Port=5432;Database=jellyfederation;Username=jellyfederation;Password=jellyfederation
+```
+
+PostgreSQL is also published on `localhost:5432` for host tools. Optional Adminer
+is at `http://localhost:8080`, optional Grafana/LGTM is at `http://localhost:3000`,
+and optional OTLP is published on `localhost:4317`/`4318`.
+
+Start optional database UI / observability services with:
+
+```bash
+docker compose -f .devcontainer/docker-compose.yml --profile db-tools up -d
+docker compose -f .devcontainer/docker-compose.yml --profile observability up -d
+```
+
+Useful devcontainer database commands:
+
+```bash
+./scripts/devcontainer-reset-db.sh
+./scripts/devcontainer-seed-db.sh
+```
+
+Start the server inside the container with:
+
+```bash
+dotnet run --project src/JellyFederation.Server/JellyFederation.Server.csproj
+```
+
+An optional full-stack compose overlay is available for containerized server, web,
+and Jellyfin services:
+
+```bash
+docker compose \
+  -f .devcontainer/docker-compose.yml \
+  -f .devcontainer/docker-compose.full.yml \
+  --profile full-stack up --build
+```
+
 Use `./dev.sh` to build/deploy the plugin and run the local Jellyfin + federation stack.
 
 Sensible default refresh (no args):

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -8,6 +8,13 @@
         "reportgenerator"
       ],
       "rollForward": false
+    },
+    "dotnet-ef": {
+      "version": "10.0.7",
+      "commands": [
+        "dotnet-ef"
+      ],
+      "rollForward": false
     }
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -12,10 +12,26 @@
     "npm",
     "dockerfile",
     "docker-compose",
-    "github-actions"
+    "github-actions",
+    "custom.regex"
   ],
   "labels": [
     "dependencies"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update .NET local tool versions in dotnet-tools.json",
+      "managerFilePatterns": [
+        "/(^|/)dotnet-tools\\.json$/",
+        "/(^|/)\\.config/dotnet-tools\\.json$/"
+      ],
+      "matchStrings": [
+        "\\\"(?<depName>[^\\\"]+)\\\"\\s*:\\s*\\{\\s*\\\"version\\\"\\s*:\\s*\\\"(?<currentValue>[^\\\"]+)\\\""
+      ],
+      "datasourceTemplate": "nuget",
+      "versioningTemplate": "nuget"
+    }
   ],
   "rangeStrategy": "bump",
   "rebaseWhen": "behind-base-branch",

--- a/scripts/devcontainer-post-start.sh
+++ b/scripts/devcontainer-post-start.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+connection_string="${ConnectionStrings__Default:-Host=postgres;Port=5432;Database=jellyfederation;Username=jellyfederation;Password=jellyfederation}"
+
+echo "Waiting for devcontainer PostgreSQL..."
+until pg_isready -h postgres -p 5432 -U jellyfederation -d jellyfederation >/dev/null 2>&1; do
+  sleep 1
+done
+
+echo "Applying PostgreSQL EF Core migrations..."
+Database__Provider=PostgreSQL \
+ConnectionStrings__Default="$connection_string" \
+dotnet dotnet-ef database update \
+  --project src/JellyFederation.Migrations.PostgreSQL/JellyFederation.Migrations.PostgreSQL.csproj
+
+echo "Devcontainer PostgreSQL is ready and migrated."

--- a/scripts/devcontainer-reset-db.sh
+++ b/scripts/devcontainer-reset-db.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+host="${POSTGRES_HOST:-postgres}"
+port="${POSTGRES_PORT:-5432}"
+database="${POSTGRES_DB:-jellyfederation}"
+user="${POSTGRES_USER:-jellyfederation}"
+export PGPASSWORD="${POSTGRES_PASSWORD:-jellyfederation}"
+
+psql -h "$host" -p "$port" -U "$user" -d postgres \
+  -v ON_ERROR_STOP=1 \
+  -c "DROP DATABASE IF EXISTS \"$database\" WITH (FORCE);" \
+  -c "CREATE DATABASE \"$database\" OWNER \"$user\";"
+
+Database__Provider=PostgreSQL \
+ConnectionStrings__Default="Host=$host;Port=$port;Database=$database;Username=$user;Password=$PGPASSWORD" \
+dotnet dotnet-ef database update \
+  --project src/JellyFederation.Migrations.PostgreSQL/JellyFederation.Migrations.PostgreSQL.csproj
+
+echo "Reset and migrated PostgreSQL database '$database'."

--- a/scripts/devcontainer-seed-db.sh
+++ b/scripts/devcontainer-seed-db.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+host="${POSTGRES_HOST:-postgres}"
+port="${POSTGRES_PORT:-5432}"
+database="${POSTGRES_DB:-jellyfederation}"
+user="${POSTGRES_USER:-jellyfederation}"
+export PGPASSWORD="${POSTGRES_PASSWORD:-jellyfederation}"
+
+psql -h "$host" -p "$port" -U "$user" -d "$database" -v ON_ERROR_STOP=1 <<'SQL'
+INSERT INTO "Servers" ("Id", "Name", "OwnerUserId", "ApiKey", "RegisteredAt", "LastSeenAt", "IsOnline") VALUES
+  ('10000000-0000-0000-0000-000000000001', 'Local Dev Jellyfin', 'dev-local', 'dev-local-api-key', now(), now(), true),
+  ('10000000-0000-0000-0000-000000000002', 'Remote Dev Jellyfin', 'dev-remote', 'dev-remote-api-key', now(), now(), false)
+ON CONFLICT ("ApiKey") DO UPDATE SET
+  "Name" = EXCLUDED."Name",
+  "OwnerUserId" = EXCLUDED."OwnerUserId",
+  "LastSeenAt" = EXCLUDED."LastSeenAt",
+  "IsOnline" = EXCLUDED."IsOnline";
+
+INSERT INTO "Invitations" ("Id", "FromServerId", "ToServerId", "Status", "CreatedAt", "RespondedAt") VALUES
+  ('20000000-0000-0000-0000-000000000001', '10000000-0000-0000-0000-000000000001', '10000000-0000-0000-0000-000000000002', 1, now(), now())
+ON CONFLICT ("Id") DO UPDATE SET
+  "Status" = EXCLUDED."Status",
+  "RespondedAt" = EXCLUDED."RespondedAt";
+
+INSERT INTO "MediaItems" ("Id", "ServerId", "JellyfinItemId", "Title", "Type", "Year", "Overview", "ImageUrl", "FileSizeBytes", "IsRequestable", "IndexedAt") VALUES
+  ('30000000-0000-0000-0000-000000000001', '10000000-0000-0000-0000-000000000002', 'dev-movie-001', 'Dev Movie', 0, 2026, 'Seeded devcontainer movie for PostgreSQL workflows.', null, 734003200, true, now()),
+  ('30000000-0000-0000-0000-000000000002', '10000000-0000-0000-0000-000000000002', 'dev-series-001', 'Dev Series', 1, 2026, 'Seeded devcontainer series for PostgreSQL workflows.', null, 0, true, now())
+ON CONFLICT ("ServerId", "JellyfinItemId") DO UPDATE SET
+  "Title" = EXCLUDED."Title",
+  "Type" = EXCLUDED."Type",
+  "Year" = EXCLUDED."Year",
+  "Overview" = EXCLUDED."Overview",
+  "FileSizeBytes" = EXCLUDED."FileSizeBytes",
+  "IsRequestable" = EXCLUDED."IsRequestable",
+  "IndexedAt" = EXCLUDED."IndexedAt";
+SQL
+
+echo "Seeded PostgreSQL database '$database'."


### PR DESCRIPTION
## Summary
- add a VS Code devcontainer backed by PostgreSQL 17
- add optional Adminer, LGTM/OTel, and full-stack compose profiles
- add scripts to migrate, reset, and seed the devcontainer PostgreSQL database
- add dotnet-ef as a local tool and configure Renovate regex updates for dotnet-tools.json

## Validation
- parsed devcontainer.json and renovate.json
- rendered base, optional profile, and full-stack compose configs
- ran bash syntax checks for devcontainer scripts
- ran dotnet tool restore