### PR TITLE
fix: use valid devcontainer base image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/dotnet:1-10.0-bookworm
+FROM mcr.microsoft.com/devcontainers/base:bookworm
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends postgresql-client \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,9 @@
   "service": "devcontainer",
   "workspaceFolder": "/workspaces/jellyfederation",
   "features": {
+    "ghcr.io/devcontainers/features/dotnet:2": {
+      "version": "10.0"
+    },
     "ghcr.io/devcontainers/features/node:1": {
       "version": "24"
     },


### PR DESCRIPTION
## Summary
- replace the unavailable mcr.microsoft.com/devcontainers/dotnet:1-10.0-bookworm image
- use the supported devcontainers base image plus the .NET 10 devcontainer feature

## Validation
- parsed devcontainer.json
- rendered devcontainer compose config
- verified mcr.microsoft.com/devcontainers/base:bookworm manifest exists